### PR TITLE
Updated CMakeList.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ catkin_package(
   roscpp
   std_msgs
   DEPENDS 
-  boost
+  Boost
   message_runtime
   )
 
@@ -94,7 +94,7 @@ add_executable(${PROJECT_NAME}
 
 ## Add dependencies to exported targets, like ROS msgs or srvs
 add_dependencies(${PROJECT_NAME}_core
-  ${catkin_EXPORTED_TARGETS}
+  ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS} 
 )
 
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_generate_messages_cpp)


### PR DESCRIPTION
- Fixed Warning: "catkin_package() DEPENDS on 'boost' but neither 'boost_INCLUDE_DIRS' nor  'boost_LIBRARIES' is defined."

Compiled using [catkin build](https://catkin-tools.readthedocs.io/en/latest/verbs/catkin_build.html) on [Ubuntu 20.04.3 LTS (Focal Fossa)](https://releases.ubuntu.com/20.04/)


