### PR TITLE
Fixed copy paste error

### DIFF
--- a/adma_ros2_driver/src/adma_parse.cpp
+++ b/adma_ros2_driver/src/adma_parse.cpp
@@ -963,7 +963,7 @@ void getmiscellaneuospoi4(const std::string& local_data, adma_msgs::msg::AdmaDat
 {
     //! miscellaneous poi 4
     char inv_path_radius_poi4[] = {local_data[376],local_data[377]};
-    memcpy(&message.invpathradius_4 , &inv_path_radius_poi4, sizeof(message.disttrav));
+    memcpy(&message.invpathradius_4 , &inv_path_radius_poi4, sizeof(message.invpathradius_4));
     message.finvpathradius_4 = message.disttrav * 0.0001;
 
     char side_slip_angle_poi4[] = {local_data[378],local_data[379]};

--- a/adma_ros2_driver/src/adma_parse.cpp
+++ b/adma_ros2_driver/src/adma_parse.cpp
@@ -109,7 +109,7 @@ void getadmastaticheader(const std::string& local_data, adma_msgs::msg::AdmaData
     memcpy(&message.serialno , &serialno, sizeof(message.serialno));
     message.genesysid =  genesysid;
     std::stringstream ss_hv;
-    ss_hv <<  int(local_data[4]) << int(local_data[5]) << int(local_data[6]) << int(local_data[15]);
+    ss_hv <<  int(local_data[4]) << int(local_data[5]) << int(local_data[6]) << int(local_data[7]);
     message.headerversion = ss_hv.str();
     std::stringstream ss_fv;
     ss_fv <<  int(local_data[12]) << int(local_data[13]) << int(local_data[14]) << int(local_data[15]);
@@ -817,7 +817,7 @@ void getexternalvecovitydigpulses(const std::string& local_data, adma_msgs::msg:
     //! external velocity digital pulses
     char ext_vel_dig_x[] = {local_data[304],local_data[305]};
     memcpy(&message.extveldigx , &ext_vel_dig_x, sizeof(message.extveldigx));
-    message.fextveldigx = message.extvelany * 0.005;
+    message.fextveldigx = message.extveldigx * 0.005;
 
     char ext_vel_dig_y[] = {local_data[306],local_data[307]};
     memcpy(&message.extveldigy , &ext_vel_dig_y, sizeof(message.extveldigy));

--- a/adma_ros2_driver/src/adma_parse.cpp
+++ b/adma_ros2_driver/src/adma_parse.cpp
@@ -1217,9 +1217,9 @@ void getgpsauxdata1(const std::string& local_data, adma_msgs::msg::AdmaData& mes
     memcpy(&message.gpsdiffage , &gps_diff_age, sizeof(message.gpsdiffage));
     message.fgpsdiffage = message.gpsdiffage * 0.1;  
     char gps_stats_used[] = {local_data[490]};
-    memcpy(&message.gpsstatsused , &gps_diff_age, sizeof(message.gpsstatsused));
+    memcpy(&message.gpsstatsused , &gps_stats_used, sizeof(message.gpsstatsused));
     char gps_stats_visible[] = {local_data[491]};
-    memcpy(&message.gpsstatsvisible , &gps_diff_age, sizeof(message.gpsstatsvisible));
+    memcpy(&message.gpsstatsvisible , &gps_stats_visible, sizeof(message.gpsstatsvisible));
 
 }
 /// \file


### PR DESCRIPTION
While building the ros2 branch, we get a warning about reading too many bytes:
```
Starting >>> adma_ros2_driver
--- stderr: adma_ros2_driver                                    
In file included from /usr/include/string.h:495,
                 from /usr/include/c++/9/cstring:42,
                 from /home/rst/AutowareAuto/src/drivers/adma_ros_driver/adma_ros2_driver/src/adma_parse.cpp:3:
In function ‘void* memcpy(void*, const void*, size_t)’,
    inlined from ‘void getmiscellaneuospoi4(const string&, adma_msgs::msg::AdmaData&)’ at /home/rst/AutowareAuto/src/drivers/adma_ros_driver/adma_ros2_driver/src/adma_parse.cpp:966:11:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:33: warning: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ reading 4 bytes from a region of size 2 [-Wstringop-overflow=]
   34 |   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
---
Finished <<< adma_ros2_driver [21.6s]
```

This was probably caused by a copy paste error. This PR fixes the issue.