### PR TITLE
Fixed boost rosdep

### DIFF
--- a/adma_ros2_driver/package.xml
+++ b/adma_ros2_driver/package.xml
@@ -8,7 +8,7 @@
    
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclcpp</depend>
-  <depend>Boost</depend>
+  <depend>boost</depend>
   <depend>adma_msgs</depend>
 
   <export>


### PR DESCRIPTION
```
rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
```
currently fails with the following error:
```
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
adma_ros2_driver: Cannot locate rosdep definition for [Boost]
```

This PR fixes the error.